### PR TITLE
Fix: models updated for API Compliance

### DIFF
--- a/core/src/main/kotlin/com/abacatepay/model/Model.kt
+++ b/core/src/main/kotlin/com/abacatepay/model/Model.kt
@@ -66,7 +66,9 @@ data class BillingResponse(
     val customer: Metadata<Customer>,
     val allowCoupons: Boolean,
     val coupons: List<String>,
-    val couponsUsed: List<String>
+    val couponsUsed: List<String>,
+    val paidAmount: Int? = null,
+    val nextBilling: String? = null
 )
 
 @Serializable

--- a/core/src/main/kotlin/com/abacatepay/model/Model.kt
+++ b/core/src/main/kotlin/com/abacatepay/model/Model.kt
@@ -10,6 +10,7 @@ data class Customer(
     val taxId: String
 )
 
+
 @Serializable
 data class Product(
     val externalId: String,
@@ -57,12 +58,15 @@ data class BillingResponse(
     val methods: List<PaymentMethod>,
     val products: List<ProductResponse>,
     val frequency: PaymentFrequency,
-    val accountId: String,
-    val storeId: String,
+    val accountId: String? = null,
+    val storeId: String? = null,
     val createdAt: String,
     val updatedAt: String,
     val metadata: BillingMetadata,
-    val customer: Metadata<Customer>
+    val customer: Metadata<Customer>,
+    val allowCoupons: Boolean,
+    val coupons: List<String>,
+    val couponsUsed: List<String>
 )
 
 @Serializable

--- a/core/src/test/kotlin/core/AbacatePayClientTest.kt
+++ b/core/src/test/kotlin/core/AbacatePayClientTest.kt
@@ -82,7 +82,8 @@ class AbacatePayClientTest {
             Metadata(customer),
             coupons = listOf("123"),
             couponsUsed = listOf(),
-            allowCoupons = true
+            allowCoupons = true,
+            paidAmount = 100
         )
 
     @Test

--- a/core/src/test/kotlin/core/AbacatePayClientTest.kt
+++ b/core/src/test/kotlin/core/AbacatePayClientTest.kt
@@ -31,6 +31,7 @@ class AbacatePayClientTest {
             listOf(product),
             "http://voltar",
             "http://completar",
+
             customer = customer
         )
 
@@ -78,7 +79,10 @@ class AbacatePayClientTest {
                 "http://voltar",
                 "http://completar"
             ),
-            Metadata(customer)
+            Metadata(customer),
+            coupons = listOf("123"),
+            couponsUsed = listOf(),
+            allowCoupons = true
         )
 
     @Test
@@ -86,7 +90,7 @@ class AbacatePayClientTest {
         val customer = customerTemplate()
         val abacatePayClient: AbacatePayClient = abacatePayClientMock(
             AbacatePayResponse(
-                createCustomeResponseTemplate(customer)
+                createCustomerResponseTemplate(customer)
             )
         )
 
@@ -116,7 +120,7 @@ class AbacatePayClientTest {
         }
     }
 
-    private fun createCustomeResponseTemplate(customer: Customer) = CreateCustomerResponse(
+    private fun createCustomerResponseTemplate(customer: Customer) = CreateCustomerResponse(
         "id",
         true,
         "accountId",


### PR DESCRIPTION
Updated models to comply with API;
The following fields where not present in the expected response: allowCoupons, coupons, couponsUsed.

Also, AccountId and StoreId seem to not be sent by the API in some cases - Which implies they are optional or not used anymore;

Without these changes, the library is unusable.