### PR TITLE
Fix: setup minimum java version 17

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'corretto'
         server-id: github
         settings-path: ${{ github.workspace }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ runBlocking {
 ## Requirements
 
 - If you are using Android, It needs to be Android 5+.
-- Java 11+
+- Java 17+
 - Kotlin 2+
 
 ## Credits

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,6 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
     extensions.configure<KotlinJvmProjectExtension> {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/samples/command-line/build.gradle
+++ b/samples/command-line/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.abacatepay:core")
+    implementation("com.github.abacatepay:core")
     implementation "ch.qos.logback:logback-classic:1.5.25"
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
 }


### PR DESCRIPTION
<!-- We appreciate this, thanks! -->
## Summary
This PR fixes the to minimum supported Java version by gradle 9.x.x

## Related Issue

Due to updating gradle to get the latest kotlin features, the lowest Java version should be 17.

## Why
This solves the CI build 

## What changed
- Minimum supported Java version to 17

## Breaking changes
- [ ] Yes
- [x] No

## Checklist
- [x] Docs updated
- [ ] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [ ] I added or updated tests (if applicable)
